### PR TITLE
Flexibility on choosing which model to use (#9)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,43 +1,37 @@
 # =============================================================================
-#                         FIRECRAWL ENVIRONMENT CONFIG
+# DEEP RESEARCH CONFIG (.env)
 # -----------------------------------------------------------------------------
-# 1) OPENAI_API_KEY is required by default unless you're exclusively using
-#    another service (e.g., DeepSeek, or a third-party OpenAI-compliant API).
-# 2) If you want to use DeepSeek, uncomment and set DEEPSEEK_API_KEY.
-# 3) FIRECRAWL_API_KEY is required. If you’re self-hosting Firecrawl or
-#    want a different base URL, uncomment and update FIRECRAWL_BASE_URL.
-# 4) For a third-party OpenAI-compliant API (like OpenRouter or Gemini),
-#    uncomment and set OPENAI_ENDPOINT.
-#
-# Comment out anything you’re not using, although leaving unused keys
-# in place won’t typically cause problems—they just won’t be used.
+# Set the defaults or override them as needed. Comment out keys you’re not using.
 # =============================================================================
 
+# Default service if user doesn’t provide --service (e.g. "openai" or "deepseek").
+DEFAULT_SERVICE="openai"
+
 # -----------------------------------------------------------------------------
-# (1) OpenAI API Key
-# Required unless you're only using DeepSeek or an OpenAI-compliant API.
+# OpenAI
 # -----------------------------------------------------------------------------
+# Required unless you're only using DeepSeek or another OpenAI-compliant API.
 OPENAI_API_KEY="your_openai_api_key_here"
+OPENAI_MODEL="o3-mini"
 
 # -----------------------------------------------------------------------------
-# (2) DeepSeek API Key
-# Uncomment if you want to switch to DeepSeek.
+# DeepSeek
 # -----------------------------------------------------------------------------
-# DEEPSEEK_API_KEY="your_deepseek_api_key_here"
+# Uncomment and set if you want to use DeepSeek.
+DEEPSEEK_API_KEY="your_deepseek_api_key_here"
+DEEPSEEK_MODEL="deepseek-reasoner"
 
 # -----------------------------------------------------------------------------
-# (3) Firecrawl API Key (Required)
+# Third-party OpenAI-compliant API endpoint
 # -----------------------------------------------------------------------------
+# Uncomment if you want to use a service that mimics OpenAI's API (e.g., OpenRouter or Gemini).
+# OPENAI_ENDPOINT="http://localhost:1234/v1"
+
+# -----------------------------------------------------------------------------
+# Firecrawl
+# -----------------------------------------------------------------------------
+# Always required.
 FIRECRAWL_API_KEY="your_firecrawl_api_key_here"
 
-# -----------------------------------------------------------------------------
-# Self-hosted Firecrawl instance (optional).
-# Uncomment if you want to override the default Firecrawl base URL.
-# -----------------------------------------------------------------------------
+# If self-hosting Firecrawl or overriding the default URL:
 # FIRECRAWL_BASE_URL="http://localhost:3002"
-
-# -----------------------------------------------------------------------------
-# (4) Third-party OpenAI-compliant API endpoint (e.g., OpenRouter or Gemini).
-# Uncomment and set if you want to use a service that mimics OpenAI's API.
-# -----------------------------------------------------------------------------
-# OPENAI_ENDPOINT="http://localhost:1234/v1"

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,43 @@
+# =============================================================================
+#                         FIRECRAWL ENVIRONMENT CONFIG
+# -----------------------------------------------------------------------------
+# 1) OPENAI_API_KEY is required by default unless you're exclusively using
+#    another service (e.g., DeepSeek, or a third-party OpenAI-compliant API).
+# 2) If you want to use DeepSeek, uncomment and set DEEPSEEK_API_KEY.
+# 3) FIRECRAWL_API_KEY is required. If you’re self-hosting Firecrawl or
+#    want a different base URL, uncomment and update FIRECRAWL_BASE_URL.
+# 4) For a third-party OpenAI-compliant API (like OpenRouter or Gemini),
+#    uncomment and set OPENAI_ENDPOINT.
+#
+# Comment out anything you’re not using, although leaving unused keys
+# in place won’t typically cause problems—they just won’t be used.
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# (1) OpenAI API Key
+# Required unless you're only using DeepSeek or an OpenAI-compliant API.
+# -----------------------------------------------------------------------------
+OPENAI_API_KEY="your_openai_api_key_here"
+
+# -----------------------------------------------------------------------------
+# (2) DeepSeek API Key
+# Uncomment if you want to switch to DeepSeek.
+# -----------------------------------------------------------------------------
+# DEEPSEEK_API_KEY="your_deepseek_api_key_here"
+
+# -----------------------------------------------------------------------------
+# (3) Firecrawl API Key (Required)
+# -----------------------------------------------------------------------------
+FIRECRAWL_API_KEY="your_firecrawl_api_key_here"
+
+# -----------------------------------------------------------------------------
+# Self-hosted Firecrawl instance (optional).
+# Uncomment if you want to override the default Firecrawl base URL.
+# -----------------------------------------------------------------------------
+# FIRECRAWL_BASE_URL="http://localhost:3002"
+
+# -----------------------------------------------------------------------------
+# (4) Third-party OpenAI-compliant API endpoint (e.g., OpenRouter or Gemini).
+# Uncomment and set if you want to use a service that mimics OpenAI's API.
+# -----------------------------------------------------------------------------
+# OPENAI_ENDPOINT="http://localhost:1234/v1"

--- a/deep_research_py/ai/providers.py
+++ b/deep_research_py/ai/providers.py
@@ -1,10 +1,15 @@
 import os
+import typer
 import tiktoken
 from typing import Optional
+from rich.console import Console
+from dotenv import load_dotenv
 from .text_splitter import RecursiveCharacterTextSplitter
 
 # Assuming we're using OpenAI's API
 import openai
+
+load_dotenv()
 
 
 def create_openai_client(api_key: str, base_url: Optional[str] = None) -> openai.OpenAI:
@@ -13,20 +18,56 @@ def create_openai_client(api_key: str, base_url: Optional[str] = None) -> openai
     )
 
 
+def create_deepseek_client(
+    api_key: str, base_url: Optional[str] = None
+) -> openai.OpenAI:
+    return openai.OpenAI(
+        api_key=api_key, base_url=base_url or "https://api.deepseek.com/v1"
+    )
+
+
 # Initialize OpenAI client with better error handling
 try:
-    api_key = os.environ.get("OPENAI_API_KEY") or os.environ.get("OPENAI_KEY")
+    api_key = os.getenv("OPENAI_API_KEY") or os.getenv("OPENAI_KEY")
     if not api_key:
         raise ValueError(
-            "OpenAI API key not found. Please set OPENAI_API_KEY environment variable."
+            "DeepSeek API key not found. Please set OPENAI_API_KEY environment variable."
         )
 
     openai_client = create_openai_client(
-        api_key=api_key, base_url=os.environ.get("OPENAI_API_ENDPOINT")
+        api_key=api_key, base_url=os.getenv("OPENAI_API_ENDPOINT")
     )
 except Exception as e:
     print(f"Error initializing OpenAI client: {e}")
     raise
+
+
+def get_ai_client(service: str, console: Console) -> openai.OpenAI:
+    # Decide which API key and endpoint to use
+    if service.lower() == "openai":
+        api_key = os.getenv("OPENAI_API_KEY")
+        endpoint = os.getenv("OPENAI_API_ENDPOINT", "https://api.openai.com/v1")
+        if not api_key:
+            console.print("[red]Missing OPENAI_API_KEY in environment[/red]")
+            raise typer.Exit(1)
+        client = create_openai_client(api_key=api_key, base_url=endpoint)
+
+        return client
+    elif service.lower() == "deepseek":
+        api_key = os.getenv("DEEPSEEK_API_KEY")
+        endpoint = os.getenv("DEEPSEEK_API_ENDPOINT", "https://api.deepseek.com/v1")
+        if not api_key:
+            console.print("[red]Missing DEEPSEEK_API_KEY in environment[/red]")
+            raise typer.Exit(1)
+        client = create_deepseek_client(api_key=api_key, base_url=endpoint)
+
+        return client
+    else:
+        console.print(
+            "[red]Invalid service selected. Choose 'openai' or 'deepseek'.[/red]"
+        )
+        raise typer.Exit(1)
+
 
 MIN_CHUNK_SIZE = 140
 encoder = tiktoken.get_encoding(
@@ -35,7 +76,7 @@ encoder = tiktoken.get_encoding(
 
 
 def trim_prompt(
-    prompt: str, context_size: int = int(os.environ.get("CONTEXT_SIZE", "128000"))
+    prompt: str, context_size: int = int(os.getenv("CONTEXT_SIZE", "128000"))
 ) -> str:
     """Trims a prompt to fit within the specified context size."""
     if not prompt:
@@ -62,4 +103,3 @@ def trim_prompt(
         return trim_prompt(prompt[:chunk_size], context_size)
 
     return trim_prompt(trimmed_prompt, context_size)
-

--- a/deep_research_py/feedback.py
+++ b/deep_research_py/feedback.py
@@ -1,18 +1,18 @@
 from typing import List
 import asyncio
+import openai
 import json
-from .ai.providers import openai_client
 from .prompt import system_prompt
 
 
-async def generate_feedback(query: str) -> List[str]:
+async def generate_feedback(query: str, client: openai.OpenAI, model: str) -> List[str]:
     """Generates follow-up questions to clarify research direction."""
 
     # Run OpenAI call in thread pool since it's synchronous
     response = await asyncio.get_event_loop().run_in_executor(
         None,
-        lambda: openai_client.chat.completions.create(
-            model="o3-mini",
+        lambda: client.chat.completions.create(
+            model=model,
             messages=[
                 {"role": "system", "content": system_prompt()},
                 {
@@ -32,4 +32,3 @@ async def generate_feedback(query: str) -> List[str]:
         print(f"Error parsing JSON response: {e}")
         print(f"Raw response: {response.choices[0].message.content}")
         return []
-

--- a/deep_research_py/run.py
+++ b/deep_research_py/run.py
@@ -1,3 +1,5 @@
+import os
+from dotenv import load_dotenv
 import asyncio
 import typer
 from functools import wraps
@@ -10,6 +12,8 @@ from rich import print as rprint
 from deep_research_py.deep_research import deep_research, write_final_report
 from deep_research_py.feedback import generate_feedback
 from .ai.providers import get_ai_client
+
+load_dotenv()
 
 app = typer.Typer()
 console = Console()
@@ -36,9 +40,12 @@ async def main(
         default=2, help="Number of concurrent tasks, depending on your API rate limits."
     ),
     service: str = typer.Option(
-        default="openai", help="Which service to use? [openai|deepseek]"
+        default=os.getenv("DEFAULT_SERVICE"),
+        help="Which service to use? [openai|deepseek]",
     ),
-    model: str = typer.Option(default="o3-mini", help="Which model to use?"),
+    model: str = typer.Option(
+        default=os.getenv("OPENAI_MODEL"), help="Which model to use?"
+    ),
 ):
     """Deep Research CLI"""
     console.print(


### PR DESCRIPTION
**Description**
This PR introduces flexibility in selecting the LLM model for deep-research-py, addressing [Issue #9](https://github.com/epuerta9/deep-research-py/issues/9).

Currently, the project uses a predefined LLM (o3-mini), but this update allows users to specify the service and model via a configuration setting. This enhances adaptability and gives users control over cost, performance, and availability.

**Changes**
- Added configuration options (env variable and cli flags) for users to specify the service and model.
- Ensured backward compatibility with the default o3-mini.

**Benefits**
- Users can choose the LLM based on their needs.
- Simplifies future integrations of additional LLMs.
- Improves project flexibility and scalability.

**Testing**
- Verified the default behavior remains unchanged.
- Tested with different model configurations. (gpt-4o, gpt-4o-mini)
- Don't have API keys to test deepseek but it should work [deepseek doc](https://api-docs.deepseek.com/)