### PR TITLE
Improve environment setup instructions and clarify service selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,26 +36,26 @@ deep_research_py/
 
 ## Installation
 
-`uv tool install deep-research-py`
-
+```bash
+uv tool install deep-research-py && cp .env.example .env
+```
 
 ## Configuration
+Open `.env` and replace placeholder values with your actual API keys
 
-Set your API keys as environment variables:
-
+### Set up environment variables in .env file:
 ```bash
 # Required: OpenAI API key
-export OPENAI_API_KEY=your-openai-key-here
-# If you want to use a third-party OpenAI compliant API (e.g., OpenRouter or Gemini), add the following below:
-# export OPENAI_API_ENDPOINT="http://localhost:1234/v1"
-# If you want to use another model or your third-party OpenAI compliant API doesn't support o3-mini, add following below:
-# export OPENAI_MODEL="<your_model_name>"
+# unless you're using DeepSeek or another OpenAI-compliant API.
+OPENAI_API_KEY=your-openai-key-here
 
 # Required: Firecrawl API key
-export FIRECRAWL_API_KEY=your-firecrawl-key-here
+FIRECRAWL_API_KEY=your-firecrawl-key-here
 # If you want to use your self-hosted Firecrawl, add the following below:
 # FIRECRAWL_BASE_URL="http://localhost:3002"
 ```
+
+Note: If you prefer, you can use DeepSeek instead of OpenAI. You can configure it in the `.env` file by setting the relevant API keys and model. Additionally, ensure that you set `DEFAULT_SERVICE` to `"deepseek"` if using DeepSeek or `"openai"` if using OpenAI.
 
 ## Usage
 
@@ -100,9 +100,10 @@ source .venv/bin/activate
 # Install in development mode
 uv pip install -e .
 
-# Set your API keys
-export OPENAI_API_KEY=your-openai-key-here
-export FIRECRAWL_KEY=your-firecrawl-key-here
+# Copy environment configuration
+cp .env.example .env
+
+# Set your API keys by editing the .env file
 
 # Run the tool
 deep-research


### PR DESCRIPTION
Description:
This PR updates the README to enhance the environment setup instructions. Specifically, it:

- Adds a step to copy .env.example to .env after installation.
- Clarifies that users can choose between OpenAI and DeepSeek as their service provider.
- Instructs users to set DEFAULT_SERVICE to either "openai" or "deepseek" accordingly.
- Ensures a more user-friendly onboarding experience by explicitly mentioning key configuration steps.
